### PR TITLE
chore(ci): upgrade GitHub Actions to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,20 +9,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout repo
 
     - name: Set up JDK 17 (LTS)
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'temurin'
         cache: maven
 
     - name: Build with Maven
       run: mvn install
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload Artifact
       with:
         name: UltimateSheepWars.jar


### PR DESCRIPTION
- Update actions/checkout from v3 to v4
- Update actions/setup-java from v3 to v4
- Update actions/upload-artifact from v3 to v4
- Change distribution from 'adopt' to 'temurin' (AdoptOpenJDK renamed)