### PR TITLE
fix(MC-1.12.X): correct wool color display in inventory

### DIFF
--- a/src/main/java/fr/royalpha/sheepwars/core/legacy/LegacyItem.java
+++ b/src/main/java/fr/royalpha/sheepwars/core/legacy/LegacyItem.java
@@ -32,7 +32,7 @@ public class LegacyItem {
     }
 
     public ItemStack getItemStack() {
-        if (SheepWarsPlugin.getVersionManager().getVersion().newerThan(MinecraftVersion.v1_12_R1)) {
+        if (SheepWarsPlugin.getVersionManager().getVersion().newerThan(MinecraftVersion.v1_13_R1)) {
             //Bukkit.broadcastMessage("no boy");
             return new ItemStack(color == null ? mat.getMaterial() : mat.getColoredMaterial(color), amount);
         } else {


### PR DESCRIPTION
Fix wrong version check causing 1.12_R1 to use 1.13+ wool materials, making all wool appear white in inventory.

Fixes #3