### PR TITLE
feat(core): implement NBT tagging for sheep items

### DIFF
--- a/src/main/java/fr/royalpha/sheepwars/api/SheepWarsSheep.java
+++ b/src/main/java/fr/royalpha/sheepwars/api/SheepWarsSheep.java
@@ -156,9 +156,14 @@ public abstract class SheepWarsSheep {
 	/**
 	 * Get the sheep icon according to the player's language.
 	 */
-	public ItemStack getIcon(Player player) {
-		return new ItemBuilder(new LegacyItem(LegacyMaterial.WOOL, this.color, 1, this.color.getWoolData())).setName(getName(player)).toItemStack();
-	}
+    public ItemStack getIcon(Player player) {
+        ItemStack item = new ItemBuilder(new LegacyItem(LegacyMaterial.WOOL, this.color, 1, this.color.getWoolData()))
+                .setName(getName(player))
+                .toItemStack();
+
+        // Add an NBT tag with the sheep ID for multilingual identification
+        return SheepWarsPlugin.getVersionManager().getNMSUtils().addNBTTag(item, "USW_SheepID", this.getId());
+    }
 
 	/**
 	 * Get the sheep duration.
@@ -303,6 +308,11 @@ public abstract class SheepWarsSheep {
 		return this.configPath.equals(other.configPath);
 	}
 
+    /**
+     @deprecated Since 5.0.8, for removal in a future version.
+     Use {@link #getCorrespondingSheepByTag} instead.
+     */
+    @Deprecated
 	public static SheepWarsSheep getCorrespondingSheep(ItemStack item, Player player) {
 		for (SheepWarsSheep sheep : availableSheeps) {
 			if (item.isSimilar(sheep.getIcon(player)))
@@ -310,6 +320,28 @@ public abstract class SheepWarsSheep {
 		}
 		return null;
 	}
+
+    /**
+     * Retrieves the sheep corresponding to an item using its NBT tag.
+     * This method is independent of the player's language.
+     *
+     * @param item  The ItemStack to identify
+     * @return The corresponding SheepWarsSheep, or null if not found
+     */
+    public static SheepWarsSheep getCorrespondingSheepByTag(ItemStack item) {
+        if (item == null) {
+            return null;
+        }
+
+        // Read the NBT tag “USW_SheepID”
+        Integer sheepId = SheepWarsPlugin.getVersionManager().getNMSUtils().getNBTTag(item, "USW_SheepID");
+
+        if (sheepId != null && sheepId >= 0 && sheepId < availableSheeps.size()) {
+            return availableSheeps.get(sheepId);
+        }
+
+        return null;
+    }
 	
 	/**
 	 * Get registered sheeps.

--- a/src/main/java/fr/royalpha/sheepwars/core/event/player/PlayerInteract.java
+++ b/src/main/java/fr/royalpha/sheepwars/core/event/player/PlayerInteract.java
@@ -50,8 +50,8 @@ public class PlayerInteract extends UltimateSheepWarsEventListener {
 			final Material mat = item.getType();
 
 			if (GameState.isStep(GameState.INGAME) && mat.toString().contains("WOOL")) {
-				
-				SheepWarsSheep sheep = SheepWarsSheep.getCorrespondingSheep(item, player);
+
+                SheepWarsSheep sheep = SheepWarsSheep.getCorrespondingSheepByTag(item);
 				int maxIntergalactic = ConfigManager.getInt(ConfigManager.Field.MAX_INTERGALACTIC_SHEEPS);
 				boolean isIntergalactic = (sheep.equals(new IntergalacticSheep()));
 				if (sheep != null && !data.getTeam().isBlocked() && !player.isInsideVehicle() && (!isIntergalactic || maxIntergalactic <= 0 || isIntergalactic && IntergalacticSheep.IN_USE < maxIntergalactic)) {

--- a/src/main/java/fr/royalpha/sheepwars/core/event/player/PlayerPickupItem.java
+++ b/src/main/java/fr/royalpha/sheepwars/core/event/player/PlayerPickupItem.java
@@ -1,42 +1,46 @@
 package fr.royalpha.sheepwars.core.event.player;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import fr.royalpha.sheepwars.api.SheepWarsSheep;
-import fr.royalpha.sheepwars.core.handler.Sounds;
-import org.bukkit.DyeColor;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.player.PlayerPickupItemEvent;
-import org.bukkit.material.Wool;
+import org.bukkit.inventory.ItemStack;
 
+import fr.royalpha.sheepwars.api.SheepWarsSheep;
 import fr.royalpha.sheepwars.core.SheepWarsPlugin;
 import fr.royalpha.sheepwars.core.event.UltimateSheepWarsEventListener;
-import fr.royalpha.sheepwars.core.util.RandomUtils;
+import fr.royalpha.sheepwars.core.handler.Sounds;
 
 public class PlayerPickupItem extends UltimateSheepWarsEventListener {
 
-	public PlayerPickupItem(final SheepWarsPlugin plugin) {
-		super(plugin);
-	}
+    public PlayerPickupItem(final SheepWarsPlugin plugin) {
+        super(plugin);
+    }
 
-	@EventHandler(priority = EventPriority.HIGHEST)
-	public void onPlayerPickupItem(final PlayerPickupItemEvent event) {
-		event.setCancelled(true);
-		if (event.getItem().getItemStack().getType().toString().contains("WOOL")) {
-			Wool wool = (Wool) event.getItem().getItemStack().getData();
-			DyeColor color = wool.getColor();
-			List<SheepWarsSheep> correspondingSheeps = new ArrayList<>();
-			for (SheepWarsSheep sheep : SheepWarsSheep.getAvailableSheeps())
-				if (sheep.getColor() == color)
-					correspondingSheeps.add(sheep);
-			if (!correspondingSheeps.isEmpty()) {
-				SheepWarsSheep sheep = RandomUtils.getRandom(correspondingSheeps);
-				event.getItem().remove();
-				Sounds.playSound(event.getPlayer(), event.getPlayer().getLocation(), Sounds.ITEM_PICKUP, 1f, 1f);
-				SheepWarsSheep.giveSheep(event.getPlayer(), sheep, event.getItem().getItemStack().getAmount());
-			}
-		}
-	}
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPlayerPickupItem(final PlayerPickupItemEvent event) {
+        Player player = event.getPlayer();
+        ItemStack item = event.getItem().getItemStack();
+
+        if (!item.getType().toString().contains("WOOL")) {
+            return;
+        }
+
+        // Identify the sheep via its NBT tag
+        SheepWarsSheep sheepType = SheepWarsSheep.getCorrespondingSheepByTag(item);
+
+        if (sheepType != null) {
+            // Cancel default pickup
+            event.setCancelled(true);
+
+            // Remove the item from the ground
+            event.getItem().remove();
+
+            // Play pickup sound
+            Sounds.playSound(player, player.getLocation(), Sounds.ITEM_PICKUP, 1f, 1f);
+
+            // Give the sheep to the player with the name in their language.
+            SheepWarsSheep.giveSheep(player, sheepType, item.getAmount());
+        }
+    }
 }

--- a/src/main/java/fr/royalpha/sheepwars/core/version/INMSUtils.java
+++ b/src/main/java/fr/royalpha/sheepwars/core/version/INMSUtils.java
@@ -23,5 +23,9 @@ public interface INMSUtils {
 	public void cancelMove(final Player player, final boolean bool);
 
 	public void updateNMSServerMOTD(final String MOTD);
-	
+
+    public ItemStack addNBTTag(final ItemStack item, final String key, final int value);
+
+    public Integer getNBTTag(final ItemStack item, final String key);
+
 }

--- a/src/main/java/fr/royalpha/sheepwars/v1_12_R1/NMSUtils.java
+++ b/src/main/java/fr/royalpha/sheepwars/v1_12_R1/NMSUtils.java
@@ -8,6 +8,7 @@ import net.minecraft.server.v1_12_R1.*;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.v1_12_R1.entity.CraftPlayer;
 import org.bukkit.craftbukkit.v1_12_R1.CraftServer;
+import org.bukkit.craftbukkit.v1_12_R1.inventory.CraftItemStack;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
@@ -111,4 +112,67 @@ public class NMSUtils implements INMSUtils {
 		MinecraftServer server = ((CraftServer) Bukkit.getServer()).getServer();
 		server.setMotd(MOTD);
 	}
+
+    @Override
+    public ItemStack addNBTTag(ItemStack item, String key, int value) {
+        if (item == null) {
+            return null;
+        }
+
+        try {
+            // Convert Bukkit ItemStack to NMS ItemStack
+            net.minecraft.server.v1_12_R1.ItemStack nmsStack = CraftItemStack.asNMSCopy(item);
+
+            // Retrieve or create the NBTTagCompound
+            NBTTagCompound tag = nmsStack.getTag();
+            if (tag == null) {
+                tag = new NBTTagCompound();
+            }
+
+            // Add the tag
+            tag.setInt(key, value);
+
+            // Save the tag on the item
+            nmsStack.setTag(tag);
+
+            // Convert back to ItemStack Bukkit
+            return CraftItemStack.asBukkitCopy(nmsStack);
+
+        } catch (Exception e) {
+            if (ConfigManager.getBoolean(ConfigManager.Field.ALLOW_DEBUG)) {
+                System.err.println("Error adding NBT tag: " + e.getMessage());
+                e.printStackTrace();
+            }
+            return item;
+        }
+    }
+
+    @Override
+    public Integer getNBTTag(ItemStack item, String key) {
+        if (item == null) {
+            return null;
+        }
+
+        try {
+            // Convert Bukkit ItemStack to NMS ItemStack
+            net.minecraft.server.v1_12_R1.ItemStack nmsStack = CraftItemStack.asNMSCopy(item);
+
+            // Retrieve the NBTTagCompound
+            NBTTagCompound tag = nmsStack.getTag();
+            if (tag == null || !tag.hasKey(key)) {
+                return null;
+            }
+
+            // Read the value
+            return tag.getInt(key);
+
+        } catch (Exception e) {
+            if (ConfigManager.getBoolean(ConfigManager.Field.ALLOW_DEBUG)) {
+                System.err.println("Error reading NBT tag: " + e.getMessage());
+                e.printStackTrace();
+            }
+            return null;
+        }
+    }
+
 }

--- a/src/main/java/fr/royalpha/sheepwars/v1_15_R1/NMSUtils.java
+++ b/src/main/java/fr/royalpha/sheepwars/v1_15_R1/NMSUtils.java
@@ -116,4 +116,67 @@ public class NMSUtils implements INMSUtils {
         net.minecraft.server.v1_15_R1.MinecraftServer server = ((CraftServer) Bukkit.getServer()).getServer();
         server.setMotd(MOTD);
     }
+
+    @Override
+    public ItemStack addNBTTag(ItemStack item, String key, int value) {
+        if (item == null) {
+            return null;
+        }
+
+        try {
+            // Convert Bukkit ItemStack to NMS ItemStack
+            net.minecraft.server.v1_15_R1.ItemStack nmsStack = CraftItemStack.asNMSCopy(item);
+
+            // Retrieve or create the NBTTagCompound
+            NBTTagCompound tag = nmsStack.getTag();
+            if (tag == null) {
+                tag = new NBTTagCompound();
+            }
+
+            // Add the tag
+            tag.setInt(key, value);
+
+            // Save the tag on the item
+            nmsStack.setTag(tag);
+
+            // Convert back to ItemStack Bukkit
+            return CraftItemStack.asBukkitCopy(nmsStack);
+
+        } catch (Exception e) {
+            if (ConfigManager.getBoolean(ConfigManager.Field.ALLOW_DEBUG)) {
+                System.err.println("Error adding NBT tag: " + e.getMessage());
+                e.printStackTrace();
+            }
+            return item;
+        }
+    }
+
+    @Override
+    public Integer getNBTTag(ItemStack item, String key) {
+        if (item == null) {
+            return null;
+        }
+
+        try {
+            // Convert Bukkit ItemStack to NMS ItemStack
+            net.minecraft.server.v1_15_R1.ItemStack nmsStack = CraftItemStack.asNMSCopy(item);
+
+            // Retrieve the NBTTagCompound
+            NBTTagCompound tag = nmsStack.getTag();
+            if (tag == null || !tag.hasKey(key)) {
+                return null;
+            }
+
+            // Read the value
+            return tag.getInt(key);
+
+        } catch (Exception e) {
+            if (ConfigManager.getBoolean(ConfigManager.Field.ALLOW_DEBUG)) {
+                System.err.println("Error reading NBT tag: " + e.getMessage());
+                e.printStackTrace();
+            }
+            return null;
+        }
+    }
+
 }

--- a/src/main/java/fr/royalpha/sheepwars/v1_8_R3/NMSUtils.java
+++ b/src/main/java/fr/royalpha/sheepwars/v1_8_R3/NMSUtils.java
@@ -110,4 +110,66 @@ public class NMSUtils implements INMSUtils {
 		MinecraftServer server = ((CraftServer)Bukkit.getServer()).getServer();
 		server.setMotd(MOTD);
 	}
+
+    @Override
+    public ItemStack addNBTTag(ItemStack item, String key, int value) {
+        if (item == null) {
+            return null;
+        }
+
+        try {
+            // Convert Bukkit ItemStack to NMS ItemStack
+            net.minecraft.server.v1_8_R3.ItemStack nmsStack = CraftItemStack.asNMSCopy(item);
+
+            // Retrieve or create the NBTTagCompound
+            NBTTagCompound tag = nmsStack.getTag();
+            if (tag == null) {
+                tag = new NBTTagCompound();
+            }
+
+            // Add the tag
+            tag.setInt(key, value);
+
+            // Save the tag on the item
+            nmsStack.setTag(tag);
+
+            // Convert back to ItemStack Bukkit
+            return CraftItemStack.asBukkitCopy(nmsStack);
+
+        } catch (Exception e) {
+            if (ConfigManager.getBoolean(ConfigManager.Field.ALLOW_DEBUG)) {
+                System.err.println("Error adding NBT tag: " + e.getMessage());
+                e.printStackTrace();
+            }
+            return item;
+        }
+    }
+
+    @Override
+    public Integer getNBTTag(ItemStack item, String key) {
+        if (item == null) {
+            return null;
+        }
+
+        try {
+            // Convert Bukkit ItemStack to NMS ItemStack
+            net.minecraft.server.v1_8_R3.ItemStack nmsStack = CraftItemStack.asNMSCopy(item);
+
+            // Retrieve the NBTTagCompound
+            NBTTagCompound tag = nmsStack.getTag();
+            if (tag == null || !tag.hasKey(key)) {
+                return null;
+            }
+
+            // Read the value
+            return tag.getInt(key);
+
+        } catch (Exception e) {
+            if (ConfigManager.getBoolean(ConfigManager.Field.ALLOW_DEBUG)) {
+                System.err.println("Error reading NBT tag: " + e.getMessage());
+                e.printStackTrace();
+            }
+            return null;
+        }
+    }
 }

--- a/src/main/java/fr/royalpha/sheepwars/v1_9_R1/NMSUtils.java
+++ b/src/main/java/fr/royalpha/sheepwars/v1_9_R1/NMSUtils.java
@@ -124,4 +124,66 @@ public class NMSUtils implements INMSUtils {
 		}
 		return meta;
 	}
+
+    @Override
+    public ItemStack addNBTTag(ItemStack item, String key, int value) {
+        if (item == null) {
+            return null;
+        }
+
+        try {
+            // Convert Bukkit ItemStack to NMS ItemStack
+            net.minecraft.server.v1_9_R1.ItemStack nmsStack = CraftItemStack.asNMSCopy(item);
+
+            // Retrieve or create the NBTTagCompound
+            NBTTagCompound tag = nmsStack.getTag();
+            if (tag == null) {
+                tag = new NBTTagCompound();
+            }
+
+            // Add the tag
+            tag.setInt(key, value);
+
+            // Save the tag on the item
+            nmsStack.setTag(tag);
+
+            // Convert back to ItemStack Bukkit
+            return CraftItemStack.asBukkitCopy(nmsStack);
+
+        } catch (Exception e) {
+            if (ConfigManager.getBoolean(ConfigManager.Field.ALLOW_DEBUG)) {
+                System.err.println("Error adding NBT tag: " + e.getMessage());
+                e.printStackTrace();
+            }
+            return item;
+        }
+    }
+
+    @Override
+    public Integer getNBTTag(ItemStack item, String key) {
+        if (item == null) {
+            return null;
+        }
+
+        try {
+            // Convert Bukkit ItemStack to NMS ItemStack
+            net.minecraft.server.v1_9_R1.ItemStack nmsStack = CraftItemStack.asNMSCopy(item);
+
+            // Retrieve the NBTTagCompound
+            NBTTagCompound tag = nmsStack.getTag();
+            if (tag == null || !tag.hasKey(key)) {
+                return null;
+            }
+
+            // Read the value
+            return tag.getInt(key);
+
+        } catch (Exception e) {
+            if (ConfigManager.getBoolean(ConfigManager.Field.ALLOW_DEBUG)) {
+                System.err.println("Error reading NBT tag: " + e.getMessage());
+                e.printStackTrace();
+            }
+            return null;
+        }
+    }
 }

--- a/src/main/java/fr/royalpha/sheepwars/v1_9_R2/NMSUtils.java
+++ b/src/main/java/fr/royalpha/sheepwars/v1_9_R2/NMSUtils.java
@@ -124,4 +124,67 @@ public class NMSUtils implements INMSUtils {
 		MinecraftServer server = ((CraftServer) Bukkit.getServer()).getServer();
 		server.setMotd(MOTD);
 	}
+
+    @Override
+    public ItemStack addNBTTag(ItemStack item, String key, int value) {
+        if (item == null) {
+            return null;
+        }
+
+        try {
+            // Convert Bukkit ItemStack to NMS ItemStack
+            net.minecraft.server.v1_9_R2.ItemStack nmsStack = CraftItemStack.asNMSCopy(item);
+
+            // Retrieve or create the NBTTagCompound
+            NBTTagCompound tag = nmsStack.getTag();
+            if (tag == null) {
+                tag = new NBTTagCompound();
+            }
+
+            // Add the tag
+            tag.setInt(key, value);
+
+            // Save the tag on the item
+            nmsStack.setTag(tag);
+
+            // Convert back to ItemStack Bukkit
+            return CraftItemStack.asBukkitCopy(nmsStack);
+
+        } catch (Exception e) {
+            if (ConfigManager.getBoolean(ConfigManager.Field.ALLOW_DEBUG)) {
+                System.err.println("Error adding NBT tag: " + e.getMessage());
+                e.printStackTrace();
+            }
+            return item;
+        }
+    }
+
+    @Override
+    public Integer getNBTTag(ItemStack item, String key) {
+        if (item == null) {
+            return null;
+        }
+
+        try {
+            // Convert Bukkit ItemStack to NMS ItemStack
+            net.minecraft.server.v1_9_R2.ItemStack nmsStack = CraftItemStack.asNMSCopy(item);
+
+            // Récupérer le NBTTagCompound
+            NBTTagCompound tag = nmsStack.getTag();
+            if (tag == null || !tag.hasKey(key)) {
+                return null;
+            }
+
+            // Read the value
+            return tag.getInt(key);
+
+        } catch (Exception e) {
+            if (ConfigManager.getBoolean(ConfigManager.Field.ALLOW_DEBUG)) {
+                System.err.println("Error reading NBT tag: " + e.getMessage());
+                e.printStackTrace();
+            }
+            return null;
+        }
+    }
+
 }


### PR DESCRIPTION
Add NBT tag 'USW_SheepID' to sheep icons for reliable identification across different languages Introduce getCorrespondingSheepByTag to replace legacy language-dependent identification Update PlayerInteract and PlayerPickupItem events to use NBT-based identification

Fixes #1