### PR TITLE
refactor(core): move item pickup cancellation logic introduced in PR #8

### DIFF
--- a/src/main/java/fr/royalpha/sheepwars/core/event/player/PlayerPickupItem.java
+++ b/src/main/java/fr/royalpha/sheepwars/core/event/player/PlayerPickupItem.java
@@ -22,6 +22,9 @@ public class PlayerPickupItem extends UltimateSheepWarsEventListener {
         Player player = event.getPlayer();
         ItemStack item = event.getItem().getItemStack();
 
+        // Cancel default pickup
+        event.setCancelled(true);
+
         if (!item.getType().toString().contains("WOOL")) {
             return;
         }
@@ -30,9 +33,6 @@ public class PlayerPickupItem extends UltimateSheepWarsEventListener {
         SheepWarsSheep sheepType = SheepWarsSheep.getCorrespondingSheepByTag(item);
 
         if (sheepType != null) {
-            // Cancel default pickup
-            event.setCancelled(true);
-
             // Remove the item from the ground
             event.getItem().remove();
 


### PR DESCRIPTION
- Moves event.setCancelled(true) to the top of onPlayerPickupItem